### PR TITLE
Unicorn/Glass.Mapper Dependency Upgrade

### DIFF
--- a/generators/app/templates/src/Foundation/DependencyInjection/tests/SolutionX.Foundation.DependencyInjection.Tests.csproj
+++ b/generators/app/templates/src/Foundation/DependencyInjection/tests/SolutionX.Foundation.DependencyInjection.Tests.csproj
@@ -63,8 +63,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Extensions.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
@@ -102,8 +102,8 @@
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Win32.Primitives.4.0.1\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Moq, Version=4.5.30.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Moq.4.5.30\lib\net45\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.10.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Moq.4.10.0\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/generators/app/templates/src/Foundation/DependencyInjection/tests/packages.config
+++ b/generators/app/templates/src/Foundation/DependencyInjection/tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
   <package id="Microsoft.Extensions.Configuration" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Extensions.Configuration.FileExtensions" version="1.0.0" targetFramework="net462" />
@@ -12,7 +12,7 @@
   <package id="Microsoft.Extensions.Logging.Abstractions" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Extensions.Primitives" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net462" />
-  <package id="Moq" version="4.5.30" targetFramework="net462" />
+  <package id="Moq" version="4.10.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net462" />
   <package id="Sitecore.FakeDb" version="1.7.2" targetFramework="net462" />

--- a/generators/app/templates/src/Foundation/GlassMapper/code/Infrastructure/GlassMapperConfigurator.cs
+++ b/generators/app/templates/src/Foundation/GlassMapper/code/Infrastructure/GlassMapperConfigurator.cs
@@ -1,6 +1,8 @@
 ﻿namespace SolutionX.Foundation.GlassMapper.Infrastructure
 {
     using Glass.Mapper.Sc;
+    using Glass.Mapper.Sc.Web;
+    using Glass.Mapper.Sc.Web.Mvc;
 
     using Microsoft.Extensions.DependencyInjection;
 
@@ -10,7 +12,9 @@
     {
         public void Configure(IServiceCollection serviceCollection)
         {
-            serviceCollection.AddTransient<ISitecoreContext>(provider => new SitecoreContext());
+            serviceCollection.AddTransient<ISitecoreService>(provider => new SitecoreService(Sitecore.Context.Database));
+            serviceCollection.AddTransient<IRequestContext>(provider => new RequestContext(provider.GetService<ISitecoreService>()));
+            serviceCollection.AddTransient<IMvcContext>(provider => new MvcContext(provider.GetService<ISitecoreService>()));
             serviceCollection.AddTransient<IGlassHtml, GlassHtml>();
         }
     }

--- a/generators/app/templates/src/Foundation/GlassMapper/code/SolutionX.Foundation.GlassMapper.csproj
+++ b/generators/app/templates/src/Foundation/GlassMapper/code/SolutionX.Foundation.GlassMapper.csproj
@@ -81,16 +81,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Glass.Mapper, Version=5.0.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.6\lib\net462\Glass.Mapper.dll</HintPath>
+    <Reference Include="Glass.Mapper, Version=5.0.8.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.8\lib\net462\Glass.Mapper.dll</HintPath>
     </Reference>
-    <Reference Include="Glass.Mapper.Sc, Version=5.0.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.6\lib\net462\Glass.Mapper.Sc.dll</HintPath>
+    <Reference Include="Glass.Mapper.Sc, Version=5.0.8.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.8\lib\net462\Glass.Mapper.Sc.dll</HintPath>
     </Reference>
-    <Reference Include="Glass.Mapper.Sc.Mvc, Version=5.0.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Mvc.5.0.6\lib\net462\Glass.Mapper.Sc.Mvc.dll</HintPath>
+    <Reference Include="Glass.Mapper.Sc.Mvc, Version=5.0.8.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Mvc.5.0.8\lib\net462\Glass.Mapper.Sc.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>

--- a/generators/app/templates/src/Foundation/GlassMapper/code/packages.config
+++ b/generators/app/templates/src/Foundation/GlassMapper/code/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.2.1" targetFramework="net462" />
-  <package id="Glass.Mapper.Sc.90" version="5.0.6" targetFramework="net462" />
-  <package id="Glass.Mapper.Sc.90.Core" version="5.0.6" targetFramework="net462" />
-  <package id="Glass.Mapper.Sc.90.Mvc" version="5.0.6" targetFramework="net462" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net462" />
+  <package id="Glass.Mapper.Sc.90" version="5.0.8" targetFramework="net462" />
+  <package id="Glass.Mapper.Sc.90.Core" version="5.0.8" targetFramework="net462" />
+  <package id="Glass.Mapper.Sc.90.Mvc" version="5.0.8" targetFramework="net462" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />

--- a/generators/app/templates/src/Foundation/Serialization/code/SolutionX.Foundation.Serialization.csproj
+++ b/generators/app/templates/src/Foundation/Serialization/code/SolutionX.Foundation.Serialization.csproj
@@ -52,20 +52,20 @@
     <Reference Include="MicroCHAP">
       <HintPath>..\..\..\packages\MicroCHAP.1.2.2.2\lib\net45\MicroCHAP.dll</HintPath>
     </Reference>
-    <Reference Include="Rainbow, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Rainbow.Core.2.0.0\lib\net452\Rainbow.dll</HintPath>
+    <Reference Include="Rainbow, Version=2.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Rainbow.Core.2.0.2\lib\net452\Rainbow.dll</HintPath>
     </Reference>
-    <Reference Include="Rainbow.Storage.Sc, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Rainbow.Storage.Sc.2.0.0\lib\net452\Rainbow.Storage.Sc.dll</HintPath>
+    <Reference Include="Rainbow.Storage.Sc, Version=2.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Rainbow.Storage.Sc.2.0.2\lib\net452\Rainbow.Storage.Sc.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Rainbow.Storage.Yaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Rainbow.Storage.Yaml.2.0.0\lib\net452\Rainbow.Storage.Yaml.dll</HintPath>
+    <Reference Include="Rainbow.Storage.Yaml, Version=2.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Rainbow.Storage.Yaml.2.0.2\lib\net452\Rainbow.Storage.Yaml.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="Unicorn, Version=4.0.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Unicorn.Core.4.0.3\lib\net452\Unicorn.dll</HintPath>
+    <Reference Include="Unicorn, Version=4.0.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Unicorn.Core.4.0.4\lib\net452\Unicorn.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/generators/app/templates/src/Foundation/Serialization/code/packages.config
+++ b/generators/app/templates/src/Foundation/Serialization/code/packages.config
@@ -3,8 +3,8 @@
   <package id="Configy" version="1.0.0" targetFramework="net462" />
   <package id="Kamsar.WebConsole" version="2.0.1" targetFramework="net462" />
   <package id="MicroCHAP" version="1.2.2.2" targetFramework="net462" />
-  <package id="Rainbow.Core" version="2.0.0" targetFramework="net462" />
-  <package id="Rainbow.Storage.Sc" version="2.0.0" targetFramework="net462" />
-  <package id="Rainbow.Storage.Yaml" version="2.0.0" targetFramework="net462" />
-  <package id="Unicorn.Core" version="4.0.3" targetFramework="net462" />
+  <package id="Rainbow.Core" version="2.0.2" targetFramework="net462" />
+  <package id="Rainbow.Storage.Sc" version="2.0.2" targetFramework="net462" />
+  <package id="Rainbow.Storage.Yaml" version="2.0.2" targetFramework="net462" />
+  <package id="Unicorn.Core" version="4.0.4" targetFramework="net462" />
 </packages>

--- a/generators/app/templates/src/scripts/jest/jest.config.js
+++ b/generators/app/templates/src/scripts/jest/jest.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   // all paths below should be assigned relative to src root
   rootDir: './../../',
-  mapCoverage: true,
   coverageReporters: ['json', 'html', 'cobertura', 'text-summary'],
   // this path is duplicated in the build.cake for xUnit tests
   coverageDirectory: './../output/tests/coverage/jest',

--- a/generators/module/templates/src/ModuleTypeX/ModuleNameX/code/SolutionX.ModuleTypeX.ModuleNameX.csproj
+++ b/generators/module/templates/src/ModuleTypeX/ModuleNameX/code/SolutionX.ModuleTypeX.ModuleNameX.csproj
@@ -114,11 +114,11 @@
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Rainbow">
-      <HintPath>..\\..\\..\\packages\\Rainbow.Core.2.0.0\\lib\\net452\\Rainbow.dll</HintPath>
+      <HintPath>..\\..\\..\\packages\\Rainbow.Core.2.0.2\\lib\\net452\\Rainbow.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Rainbow.Storage.Yaml">
-      <HintPath>..\\..\\..\\packages\\Rainbow.Storage.Yaml.2.0.0\\lib\\net452\\Rainbow.Storage.Yaml.dll</HintPath>
+      <HintPath>..\\..\\..\\packages\\Rainbow.Storage.Yaml.2.0.2\\lib\\net452\\Rainbow.Storage.Yaml.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/generators/module/templates/src/ModuleTypeX/ModuleNameX/code/SolutionX.ModuleTypeX.ModuleNameX.csproj
+++ b/generators/module/templates/src/ModuleTypeX/ModuleNameX/code/SolutionX.ModuleTypeX.ModuleNameX.csproj
@@ -44,13 +44,13 @@
   </PropertyGroup>
   <ItemGroup>
 <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Glass.Mapper, Version=5.0.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.6\lib\net462\Glass.Mapper.dll</HintPath>
+    <Reference Include="Glass.Mapper, Version=5.0.8.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.8\lib\net462\Glass.Mapper.dll</HintPath>
     </Reference>
-    <Reference Include="Glass.Mapper.Sc, Version=5.0.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.6\lib\net462\Glass.Mapper.Sc.dll</HintPath>
+    <Reference Include="Glass.Mapper.Sc, Version=5.0.8.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.8\lib\net462\Glass.Mapper.Sc.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>

--- a/generators/module/templates/src/ModuleTypeX/ModuleNameX/code/packages.config
+++ b/generators/module/templates/src/ModuleTypeX/ModuleNameX/code/packages.config
@@ -25,7 +25,7 @@
   <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net462" />
   <package id="System.Threading" version="4.0.11" targetFramework="net462" />
   <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net462" />
-  <package id="Rainbow.Core" version="2.0.0" targetFramework="net462" />
-  <package id="Rainbow.Storage.Yaml" version="2.0.0" targetFramework="net462" />
+  <package id="Rainbow.Core" version="2.0.2" targetFramework="net462" />
+  <package id="Rainbow.Storage.Yaml" version="2.0.2" targetFramework="net462" />
   <package id="RainbowCodeGeneration" version="0.3.0" targetFramework="net462" />
 </packages>

--- a/generators/module/templates/src/ModuleTypeX/ModuleNameX/code/packages.config
+++ b/generators/module/templates/src/ModuleTypeX/ModuleNameX/code/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
- <package id="Castle.Core" version="4.2.1" targetFramework="net462" />
-  <package id="Glass.Mapper.Sc.90.Core" version="5.0.6" targetFramework="net462" />
+ <package id="Castle.Core" version="4.3.1" targetFramework="net462" />
+  <package id="Glass.Mapper.Sc.90.Core" version="5.0.8" targetFramework="net462" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net462" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net462" />

--- a/generators/module/templates/src/ModuleTypeX/ModuleNameX/tests/SolutionX.ModuleTypeX.ModuleNameX.Tests.csproj
+++ b/generators/module/templates/src/ModuleTypeX/ModuleNameX/tests/SolutionX.ModuleTypeX.ModuleNameX.Tests.csproj
@@ -45,8 +45,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="FluentAssertions, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.dll</HintPath>
@@ -54,16 +54,16 @@
     <Reference Include="FluentAssertions.Core, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Glass.Mapper, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Glass.Mapper.Sc.Core.4.5.0.4\lib\net45\Glass.Mapper.dll</HintPath>
+    <Reference Include="Glass.Mapper, Version=5.0.8.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.8.0\lib\net45\Glass.Mapper.dll</HintPath>
     </Reference>
-    <Reference Include="Glass.Mapper.Sc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Glass.Mapper.Sc, Version=5.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Glass.Mapper.Sc.Core.4.5.0.4\lib\111\Glass.Mapper.Sc.dll</HintPath>
+      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.8.0\lib\111\Glass.Mapper.Sc.dll</HintPath>
     </Reference>
-    <Reference Include="Glass.Mapper.Sc.Mvc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Glass.Mapper.Sc.Mvc, Version=5.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Glass.Mapper.Sc.Core.4.5.0.4\lib\Mvc52\Glass.Mapper.Sc.Mvc.dll</HintPath>
+      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.8.0\lib\Mvc52\Glass.Mapper.Sc.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.4.9.5, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\HtmlAgilityPack.1.4.9.5\lib\Net45\HtmlAgilityPack.dll</HintPath>

--- a/generators/module/templates/src/ModuleTypeX/ModuleNameX/tests/packages.config
+++ b/generators/module/templates/src/ModuleTypeX/ModuleNameX/tests/packages.config
@@ -4,9 +4,9 @@
   <package id="AutoFixture.AutoMoq" version="3.51.0" targetFramework="net462" />
   <package id="AutoFixture.AutoNSubstitute" version="3.51.0" targetFramework="net462" />
   <package id="AutoFixture.Xunit2" version="3.51.0" targetFramework="net462" />
-  <package id="Castle.Core" version="3.3.3" targetFramework="net462" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net462" />
   <package id="FluentAssertions" version="4.19.4" targetFramework="net462" />
-  <package id="Glass.Mapper.Sc.Core" version="4.5.0.4" targetFramework="net462" />
+  <package id="Glass.Mapper.Sc.90.Core" version="5.0.8" targetFramework="net462" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net462" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net462" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net462" />
@@ -15,7 +15,7 @@
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
-  <package id="Moq" version="4.5.30" targetFramework="net462" />
+  <package id="Moq" version="4.10.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net462" />
   <package id="RazorGenerator.Mvc" version="2.4.9" targetFramework="net462" />


### PR DESCRIPTION
- Removed ancillary mapCoverage option from jest config
- Upgraded to most recent version of Unicorn (4.0.4) and Rainbow (2.0.2)
- Upgraded to most recent version of Glass.Mapper (5.0.8)
- Removed obsolete reference to ISitecoreContext and replaced with references to IRequestContext and IMvcContext