### PR TITLE
Incorrect module Glass.Mapper Hint Path

### DIFF
--- a/generators/module/templates/src/ModuleTypeX/ModuleNameX/tests/SolutionX.ModuleTypeX.ModuleNameX.Tests.csproj
+++ b/generators/module/templates/src/ModuleTypeX/ModuleNameX/tests/SolutionX.ModuleTypeX.ModuleNameX.Tests.csproj
@@ -45,7 +45,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="FluentAssertions, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
@@ -55,15 +55,15 @@
       <HintPath>..\..\..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
     <Reference Include="Glass.Mapper, Version=5.0.8.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.8.0\lib\net45\Glass.Mapper.dll</HintPath>
+      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.8\lib\net462\Glass.Mapper.dll</HintPath>
     </Reference>
     <Reference Include="Glass.Mapper.Sc, Version=5.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.8.0\lib\111\Glass.Mapper.Sc.dll</HintPath>
+      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.8\lib\net462\Glass.Mapper.Sc.dll</HintPath>
     </Reference>
     <Reference Include="Glass.Mapper.Sc.Mvc, Version=5.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Core.5.0.8.0\lib\Mvc52\Glass.Mapper.Sc.Mvc.dll</HintPath>
+      <HintPath>..\..\..\packages\Glass.Mapper.Sc.90.Mvc.5.0.8\lib\net462\Glass.Mapper.Sc.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.4.9.5, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\HtmlAgilityPack.1.4.9.5\lib\Net45\HtmlAgilityPack.dll</HintPath>
@@ -84,8 +84,8 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="Moq, Version=4.5.30.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Moq.4.5.30\lib\net45\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.10.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Moq.4.10.0\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -135,8 +135,8 @@
     <Reference Include="Sitecore.ExperienceEditor, Version=4.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Sitecore.ExperienceEditor.NoReferences.9.0.171219\lib\NET462\Sitecore.ExperienceEditor.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.FakeDb, Version=1.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Sitecore.FakeDb.1.7.0\lib\net45\Sitecore.FakeDb.dll</HintPath>
+    <Reference Include="Sitecore.FakeDb, Version=1.7.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Sitecore.FakeDb.1.7.2\lib\net45\Sitecore.FakeDb.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.FakeDb.AutoFixture, Version=1.7.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.7.0\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>

--- a/generators/module/templates/src/ModuleTypeX/ModuleNameX/tests/packages.config
+++ b/generators/module/templates/src/ModuleTypeX/ModuleNameX/tests/packages.config
@@ -29,7 +29,7 @@
   <package id="Sitecore.ContentSearch.Linq.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="Sitecore.ContentSearch.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="Sitecore.ExperienceEditor.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
-  <package id="Sitecore.FakeDb" version="1.7.0" targetFramework="net462" />
+  <package id="Sitecore.FakeDb" version="1.7.2" targetFramework="net462" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.7.0" targetFramework="net462" />
   <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="Sitecore.Logging.Client.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />


### PR DESCRIPTION
- Fixed issue with incorrect Glass.Mapper hint path in generated module projects.
- Consolidated Sitecore.FakeDb version with primary project generation.